### PR TITLE
Fix: Capybara warning

### DIFF
--- a/fake_braintree.gemspec
+++ b/fake_braintree.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activesupport'
   s.add_dependency 'braintree', '~> 2.32'
-  s.add_dependency 'capybara', '>= 2.2.0'
+  s.add_dependency 'capybara', '~> 3.16'
   s.add_dependency 'sinatra'
 
   s.add_development_dependency 'rake'

--- a/lib/fake_braintree/server.rb
+++ b/lib/fake_braintree/server.rb
@@ -10,6 +10,6 @@ class FakeBraintree::Server
 
   def initialize(options = {})
     app = FakeBraintree::SinatraApp
-    @server = Capybara::Server.new(app, options.fetch(:port, nil), SERVER_HOST)
+    @server = Capybara::Server.new(app, port: options.fetch(:port, nil), host: SERVER_HOST)
   end
 end


### PR DESCRIPTION
## What did we change?
* Fix deprecation warning from Capybara:

```
Positional arguments, other than the application, to Server#new are deprecated, please use keyword arguments
```

## Why are we doing this?

Honestly, for the dumb reason that deprecation warnings in rspec bother me too much so this PR is to shut up the warning. We call the fake braintree in the ez-Rails [helper](https://github.com/ezcater/ez-rails/blob/93f7113fc33dcdf5259eab5300c74d159aa3341d/spec/rails_helper.rb#L54)

With [Capybara 3.16](https://github.com/teamcapybara/capybara/blob/5cac4df9bcea9ffb0377ab7008c9a675d1ab79c5/lib/capybara/server.rb#L27), positional arguments will throw a deprecation warning.

## How was it tested?
- [ ] Specs
- [x] via Circle CI (cuz it's quicker than running all locally):
  * Create a [branch](https://github.com/ezcater/ez-rails/compare/tv/testing_fake_braintree?expand=1) with this change (currently 5abc950)
  * Check [Circle CI](https://circleci.com/gh/ezcater/ez-rails/86256?utm_campaign=vcs-integration-link&utm_medium=referral) (branch and master)
  * Verify that the branch is still green
  * Verify by grepping `positional arguments` in the UI
  
<img width="978" alt="Screen Shot 2019-07-03 at 2 10 07 PM" src="https://user-images.githubusercontent.com/2018474/60615090-53ecd600-9d9c-11e9-9d36-64efc49168bf.png">
Master ^^ 

<img width="1052" alt="Screen Shot 2019-07-03 at 2 11 22 PM" src="https://user-images.githubusercontent.com/2018474/60615151-7c74d000-9d9c-11e9-9ee4-16cc8e5acd95.png">
Test Branch ^^

- [ ] Staging
- [ ] Migrations Reviewed (Zero Downtime)